### PR TITLE
fix bug: when did load more , infiniteView just stop [self.activityIn…

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -284,16 +284,22 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         
         switch (newState) {
             case SVInfiniteScrollingStateStopped:
+            {
+                [self resetScrollViewContentInset];
                 [self.activityIndicatorView stopAnimating];
                 break;
-                
+            }
             case SVInfiniteScrollingStateTriggered:
+            {
                 [self.activityIndicatorView startAnimating];
                 break;
-                
+            }
             case SVInfiniteScrollingStateLoading:
+            {
+                [self setScrollViewContentInsetForInfiniteScrolling];
                 [self.activityIndicatorView startAnimating];
                 break;
+            }
         }
     }
     


### PR DESCRIPTION
…dicatorView stopAnimating] , but not resetScrollViewContentInset; otherwise the state is SVInfiniteScrollingStateLoading should setScrollViewContentInsetForInfiniteScrolling.
